### PR TITLE
Add Calva REPL connect settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 .settings
 .socket-repl-port
 .sw*
-.vscode
 *.class
 *.jar
 *.swp

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "calva.replConnectSequences": [
+        {
+            "name": "Road to Reality REPL",
+            "projectType": "deps.edn",
+            "projectRootPath": ["."],
+            "afterCLJReplJackInCode": "(user/serve! {:port 6789})",
+            "autoSelectForJackIn": true,
+            "autoSelectForConnect": true,
+            "menuSelections": {
+                "cljAliases": [":nextjournal/clerk"]
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ and navigate to the `essays/reality/introduction.clj` file.
 
 ## Editing the Essays
 
+For this you can choose either to use the `clerk-watch` Babashka task or the 
+Clojure REPL. (If you are using Calva it is easiest with the REPL alternative).
+
+### Babashka `clerk-watch`
+
 Back at your terminal, run the following command:
 
 ```
@@ -194,18 +199,43 @@ introduction essay with your change, you're now in business! Read in the browser
 pane, and edit any example you find in the essays. A simple edit-and-save should
 cause everything to update.
 
-## REPL-Based Exploration
-
-Alternatively, instead of `bb clerk-watch` follow your editor's instructions
-(see ["Choosing an Editor"](#choosing-an-editor) above) to start a Clojure REPL,
-and then run `(user/serve!)`.
+### REPL-Based Exploration
 
 Running the essays this way will let you use the Clojure REPL to explore.
+Depending on which editor you are using (or if you are even using an editor) the
+process look a bit different.
+
+#### Calva
+
+1. Use the command: **Calva: Start a Project REPL and Connect (a.k.a. Jack-in)**
+
+   This will start the server and open your web browser at http://localhost:6789/.
+   You can also open this URL in VS Code's **Simple Browser** for a more
+   integrated experience. (If you do, close the auto-opened browser tab).
+1. Edit some prose in the file `essays/reality/index.clj` and save it.
+
+   The browser should update and show your edit. You are in business!
+
+To work with some other file, say `essays/reality/introduction.md`: in the
+Output/REPL window (`output.calva-repl`) enter:
+
+```clojure
+(nextjournal.clerk/show! "essays/reality/introduction.md")
+```
+
+And press `enter`.
+
+#### Other editors
+
+Follow your editor's instructions (see ["Choosing an Editor"](#choosing-an-editor)
+above) to start a Clojure REPL, and then run `(user/serve!)`.
 
 To show or reload a particular notebook, call `nextjournal.clerk/show!` with the
 file's path as argument. The [Book of Clerk](https://book.clerk.vision) has
 [good instructions on how to configure your editor for
 this](https://book.clerk.vision/#editor-integration).
+
+#### No editor
 
 You can try this without any editor support by starting a REPL from the command
 line:


### PR DESCRIPTION
Addressing:
* #7

I've added a [Calva Custom Connect Sequence](https://calva.io/connect-sequences/) to streamline the starting of the REPL. And I then also added a Calva section in the README. Maybe it could be an `editors.md` file at some point...

Please note that I've also remove `.vscode` from `.gitignore`, since the settings are in this folder. (And I generally think it makes sense to keep this file in the repo.)